### PR TITLE
Add conversions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.xml "0.2.0-alpha2"]
-                 [org.clojure/data.csv "0.1.4"]]
+                 [org.clojure/data.csv "0.1.4"]
+                 [org.clojure/core.async "0.3.443"]]
   :main ^:skip-aot vip-feed-format-converter.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}

--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -4,6 +4,9 @@
             [vip-feed-format-converter.xml2csv.electoral-district
              :as electoral-district]
             [vip-feed-format-converter.xml2csv.locality :as locality]
+            [vip-feed-format-converter.xml2csv.polling-location
+             :as polling-location]
+            [vip-feed-format-converter.xml2csv.precinct :as precinct]
             [vip-feed-format-converter.xml2csv.source :as source]
             [vip-feed-format-converter.xml2csv.state :as state]
             [vip-feed-format-converter.xml2csv.street-segment
@@ -23,22 +26,33 @@
 (defn set-handlers [ctx]
   (assoc ctx :handlers
          {:VipObject
-          {:Election election/handlers
-           :Locality locality/handlers
-           :ElectoralDistrict electoral-district/handlers
-           :Source source/handlers
-           :State state/handlers
-           :StreetSegment street-segment/handlers}}))
+          {:Election           election/handlers
+           :Locality           locality/handlers
+           :ElectoralDistrict  electoral-district/handlers
+           :PollingLocation    polling-location/handlers
+           :Precinct           precinct/handlers
+           :Source             source/handlers
+           :State              state/handlers
+           :StreetSegment      street-segment/handlers}}))
 
 (defn set-headers [ctx]
   (-> ctx
-      (assoc-in [:csv-data :election :headers] election/headers)
-      (assoc-in [:csv-data :locality :headers] locality/headers)
+      (assoc-in [:csv-data :election :headers]
+                election/headers)
+      (assoc-in [:csv-data :locality :headers]
+                locality/headers)
       (assoc-in [:csv-data :electoral-district :headers]
                 electoral-district/headers)
-      (assoc-in [:csv-data :source :headers] source/headers)
-      (assoc-in [:csv-data :state :headers] state/headers)
-      (assoc-in [:csv-data :street-segment :headers] street-segment/headers)))
+      (assoc-in [:csv-data :polling-location :headers]
+                polling-location/headers)
+      (assoc-in [:csv-data :precinct :headers]
+                precinct/headers)
+      (assoc-in [:csv-data :source :headers]
+                source/headers)
+      (assoc-in [:csv-data :state :headers]
+                state/headers)
+      (assoc-in [:csv-data :street-segment :headers]
+                street-segment/headers)))
 
 (defn process [in-file out-dir]
   (-> {:in-file in-file

--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -2,6 +2,8 @@
   (:require [vip-feed-format-converter.csv :as csv]
             [vip-feed-format-converter.xml2csv.election :as election]
             [vip-feed-format-converter.xml2csv.locality :as locality]
+            [vip-feed-format-converter.xml2csv.electoral-district
+             :as electoral-district]
             [vip-feed-format-converter.xml :as xml]
             [clojure.java.io :as io])
   (:gen-class))
@@ -14,17 +16,19 @@
     (.close input))
   (dissoc ctx :input))
 
-(defn election-headers [ctx]
-  (assoc-in ctx [:csv-data :election :headers] election/headers))
-
-(defn locality-headers [ctx]
-  (assoc-in ctx [:csv-data :locality :headers] locality/headers))
-
 (defn set-handlers [ctx]
   (assoc ctx :handlers
          {:VipObject
           {:Election election/handlers
-           :Locality locality/handlers}}))
+           :Locality locality/handlers
+           :ElectoralDistrict electoral-district/handlers}}))
+
+(defn set-headers [ctx]
+  (-> ctx
+      (assoc-in [:csv-data :election :headers] election/headers)
+      (assoc-in [:csv-data :locality :headers] locality/headers)
+      (assoc-in [:csv-data :electoral-district :headers]
+                electoral-district/headers)))
 
 (defn process [in-file out-dir]
   (-> {:in-file in-file
@@ -32,8 +36,7 @@
        :tag-path []}
       open-input-file
       set-handlers
-      election-headers
-      locality-headers
+      set-headers
       xml/parse-file
       csv/write-files
       close-input-file))

--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -4,6 +4,7 @@
             [vip-feed-format-converter.xml2csv.electoral-district
              :as electoral-district]
             [vip-feed-format-converter.xml2csv.locality :as locality]
+            [vip-feed-format-converter.xml2csv.source :as source]
             [vip-feed-format-converter.xml2csv.street-segment
              :as street-segment]
             [vip-feed-format-converter.xml :as xml]
@@ -24,6 +25,7 @@
           {:Election election/handlers
            :Locality locality/handlers
            :ElectoralDistrict electoral-district/handlers
+           :Source source/handlers
            :StreetSegment street-segment/handlers}}))
 
 (defn set-headers [ctx]
@@ -32,6 +34,7 @@
       (assoc-in [:csv-data :locality :headers] locality/headers)
       (assoc-in [:csv-data :electoral-district :headers]
                 electoral-district/headers)
+      (assoc-in [:csv-data :source :headers] source/headers)
       (assoc-in [:csv-data :street-segment :headers] street-segment/headers)))
 
 (defn process [in-file out-dir]

--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -1,9 +1,11 @@
 (ns vip-feed-format-converter.core
   (:require [vip-feed-format-converter.csv :as csv]
             [vip-feed-format-converter.xml2csv.election :as election]
-            [vip-feed-format-converter.xml2csv.locality :as locality]
             [vip-feed-format-converter.xml2csv.electoral-district
              :as electoral-district]
+            [vip-feed-format-converter.xml2csv.locality :as locality]
+            [vip-feed-format-converter.xml2csv.street-segment
+             :as street-segment]
             [vip-feed-format-converter.xml :as xml]
             [clojure.java.io :as io])
   (:gen-class))
@@ -21,14 +23,16 @@
          {:VipObject
           {:Election election/handlers
            :Locality locality/handlers
-           :ElectoralDistrict electoral-district/handlers}}))
+           :ElectoralDistrict electoral-district/handlers
+           :StreetSegment street-segment/handlers}}))
 
 (defn set-headers [ctx]
   (-> ctx
       (assoc-in [:csv-data :election :headers] election/headers)
       (assoc-in [:csv-data :locality :headers] locality/headers)
       (assoc-in [:csv-data :electoral-district :headers]
-                electoral-district/headers)))
+                electoral-district/headers)
+      (assoc-in [:csv-data :street-segment :headers] street-segment/headers)))
 
 (defn process [in-file out-dir]
   (-> {:in-file in-file

--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -5,6 +5,7 @@
              :as electoral-district]
             [vip-feed-format-converter.xml2csv.locality :as locality]
             [vip-feed-format-converter.xml2csv.source :as source]
+            [vip-feed-format-converter.xml2csv.state :as state]
             [vip-feed-format-converter.xml2csv.street-segment
              :as street-segment]
             [vip-feed-format-converter.xml :as xml]
@@ -26,6 +27,7 @@
            :Locality locality/handlers
            :ElectoralDistrict electoral-district/handlers
            :Source source/handlers
+           :State state/handlers
            :StreetSegment street-segment/handlers}}))
 
 (defn set-headers [ctx]
@@ -35,6 +37,7 @@
       (assoc-in [:csv-data :electoral-district :headers]
                 electoral-district/headers)
       (assoc-in [:csv-data :source :headers] source/headers)
+      (assoc-in [:csv-data :state :headers] state/headers)
       (assoc-in [:csv-data :street-segment :headers] street-segment/headers)))
 
 (defn process [in-file out-dir]
@@ -53,4 +56,3 @@
   (println "Reading XML feed from" in-file "and outputting CSV files to"
            (str out-dir "/") "\n")
   (process in-file out-dir))
-

--- a/src/vip_feed_format_converter/csv.clj
+++ b/src/vip_feed_format_converter/csv.clj
@@ -7,21 +7,21 @@
   "Sets up to write to a CSV based on pulling values from the
    supplied async channel."
   [ctx type headers channel]
-  (update-in ctx [:write-channels] conj
-             (async/thread
-               (println "Start writing stream for" (name type))
-               (with-open [csv-file (io/writer (str (:out-dir ctx)
-                                                    "/" (name type) ".csv"))]
-                 ;; write the file header
-                 (csv/write-csv csv-file [(map name headers)])
-                 ;; write data as it streams in
-                 (loop [data (async/<!! channel)]
-                   (when data
-                     (csv/write-csv csv-file [(map #(get data %) headers)])
-                     (recur (async/<!! channel))))
-                 (println "Stop writing stream for" (name type)))
-               ;; return something on the thread channel
-               type)))
+  (update ctx :write-channels conj
+          (async/thread
+            (println "Start writing stream for" (name type))
+            (with-open [csv-file (io/writer (str (:out-dir ctx)
+                                                 "/" (name type) ".csv"))]
+              ;; write the file header
+              (csv/write-csv csv-file [(map name headers)])
+              ;; write data as it streams in
+              (loop [data (async/<!! channel)]
+                (when data
+                  (csv/write-csv csv-file [(map #(get data %) headers)])
+                  (recur (async/<!! channel))))
+              (println "Stop writing stream for" (name type)))
+            ;; return something on the thread channel
+            type)))
 
 (defn write-files [ctx]
   (println "Writing cached files")

--- a/src/vip_feed_format_converter/csv.clj
+++ b/src/vip_feed_format_converter/csv.clj
@@ -24,7 +24,7 @@
             type)))
 
 (defn write-files [ctx]
-  (println "Writing cached files")
+  (println "Writing :csv-data files")
   (doseq [[file {:keys [headers data]}] (:csv-data ctx)]
     (let [csv-data (reduce (fn [m d]
                              (conj m
@@ -34,5 +34,5 @@
       (with-open [csv-file (io/writer (str (:out-dir ctx)
                                            "/" (name file) ".csv"))]
         (csv/write-csv csv-file csv-data))))
-  (println "Done writing cached files")
+  (println "Done writing :csv-data files")
   ctx)

--- a/src/vip_feed_format_converter/csv.clj
+++ b/src/vip_feed_format_converter/csv.clj
@@ -24,6 +24,7 @@
                type)))
 
 (defn write-files [ctx]
+  (println "Writing cached files")
   (doseq [[file {:keys [headers data]}] (:csv-data ctx)]
     (let [csv-data (reduce (fn [m d]
                              (conj m
@@ -32,4 +33,6 @@
                            [(map name headers)] data)]
       (with-open [csv-file (io/writer (str (:out-dir ctx)
                                            "/" (name file) ".csv"))]
-        (csv/write-csv csv-file csv-data)))))
+        (csv/write-csv csv-file csv-data))))
+  (println "Done writing cached files")
+  ctx)

--- a/src/vip_feed_format_converter/csv.clj
+++ b/src/vip_feed_format_converter/csv.clj
@@ -1,6 +1,27 @@
 (ns vip-feed-format-converter.csv
   (:require [clojure.data.csv :as csv]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.core.async :as async]))
+
+(defn setup-writer
+  "Sets up to write to a CSV based on pulling values from the
+   supplied async channel."
+  [ctx type headers channel]
+  (update-in ctx [:write-channels] conj
+             (async/thread
+               (println "Start writing stream for" (name type))
+               (with-open [csv-file (io/writer (str (:out-dir ctx)
+                                                    "/" (name type) ".csv"))]
+                 ;; write the file header
+                 (csv/write-csv csv-file [(map name headers)])
+                 ;; write data as it streams in
+                 (loop [data (async/<!! channel)]
+                   (when data
+                     (csv/write-csv csv-file [(map #(get data %) headers)])
+                     (recur (async/<!! channel))))
+                 (println "Stop writing stream for" (name type)))
+               ;; return something on the thread channel
+               type)))
 
 (defn write-files [ctx]
   (doseq [[file {:keys [headers data]}] (:csv-data ctx)]

--- a/src/vip_feed_format_converter/xml.clj
+++ b/src/vip_feed_format_converter/xml.clj
@@ -30,6 +30,7 @@
       (assoc ctx :tag-path next-tag-path))))
 
 (defn parse-file [{:keys [input] :as ctx}]
+  (println "Parsing xml file")
   (let [events (xml/event-seq input {})]
     (loop [event (first events)
            prior-event nil
@@ -45,4 +46,6 @@
                  (rest remaining-events)
                  next-ctx
                  (inc iteration))
-          next-ctx)))))
+          (do
+            (println "\nDone parsing xml file")
+            next-ctx))))))

--- a/src/vip_feed_format_converter/xml2csv/election.clj
+++ b/src/vip_feed_format_converter/xml2csv/election.clj
@@ -8,44 +8,33 @@
    :registration_deadline :absentee_request_deadline
    :hours_open_id])
 
-(def assoc-chars (partial util/assoc-chars :election))
+(defn assoc-chars [key]
+  (fn [ctx value]
+    (util/assoc-chars :election ctx value key)))
 
-(def assoc-intl-text (partial util/assoc-intl-text :election "en"))
+(defn assoc-intl-text [key]
+  (fn [ctx value]
+    (util/assoc-intl-text :election "en" ctx value key)))
 
 (def handlers
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :election]
                       {:id (get-in event [:attrs :id])}))
-   :Date {:chars (fn [ctx event] (assoc-chars ctx event :date))}
-   :Name {:Text {:chars (fn [ctx event]
-                          (assoc-intl-text ctx event :name))}}
-   :ElectionType {:Text {:chars
-                         (fn [ctx event]
-                           (assoc-intl-text ctx event :election_type))}}
-   :StateId {:chars (fn [ctx event]
-                      (assoc-chars ctx event :state_id))}
-   :IsStatewide {:chars (fn [ctx event]
-                          (assoc-chars ctx event :is_statewide))}
-   :RegistrationInfo {:chars (fn [ctx event]
-                               (assoc-intl-text ctx event :registration_info))}
-   :AbsenteeBallotInfo {:chars (fn [ctx event]
-                                 (assoc-intl-text ctx event
-                                                  :absentee_ballot_info))}
-   :ResultsUri {:chars (fn [ctx event]
-                         (assoc-chars ctx event :results_uri))}
-   :PollingHours {:chars (fn [ctx event]
-                           (assoc-intl-text ctx event :polling_hours))}
-   :HoursOpenId {:chars (fn [ctx event]
-                          (assoc-chars ctx event :hours_open_id))}
+   :Date                 {:chars (assoc-chars :date)}
+   :Name          {:Text {:chars (assoc-intl-text :name)}}
+   :ElectionType  {:Text {:chars (assoc-intl-text :election_type)}}
+   :StateId              {:chars (assoc-chars :state_id)}
+   :IsStatewide          {:chars (assoc-chars :is_statewide)}
+   :RegistrationInfo     {:chars (assoc-intl-text :registration_info)}
+   :AbsenteeBallotInfo   {:chars (assoc-intl-text :absentee_ballot_info)}
+   :ResultsUri           {:chars (assoc-chars :results_uri)}
+   :PollingHours         {:chars (assoc-intl-text :polling_hours)}
+   :HoursOpenId          {:chars (assoc-chars :hours_open_id)}
    :HasElectionDayRegistration
-   {:chars (fn [ctx event]
-             (assoc-chars ctx event :has_election_day_registration))}
-   :RegistrationDeadline
-   {:chars (fn [ctx event]
-             (assoc-chars ctx event :registration_deadline))}
+                         {:chars (assoc-chars :has_election_day_registration)}
+   :RegistrationDeadline {:chars (assoc-chars :registration_deadline)}
    :AbsenteeRequestDeadline
-   {:chars (fn [ctx event]
-             (assoc-chars ctx event :absentee_request_deadline))}
+                         {:chars (assoc-chars :absentee_request_deadline)}
    :end (fn [ctx _]
           (-> ctx
               (update-in [:csv-data :election :data]

--- a/src/vip_feed_format_converter/xml2csv/electoral_district.clj
+++ b/src/vip_feed_format_converter/xml2csv/electoral_district.clj
@@ -14,6 +14,7 @@
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :electoral-district]
                       {:id (get-in event [:attrs :id])}))
+   ;; Note, will currently only save the LAST External Identifier in the CSV
    :ExternalIdentifiers
    {:ExternalIdentifier
     {:Type        {:chars (assoc-chars :external_identifier_type)}

--- a/src/vip_feed_format_converter/xml2csv/electoral_district.clj
+++ b/src/vip_feed_format_converter/xml2csv/electoral_district.clj
@@ -8,7 +8,7 @@
 
 (defn assoc-chars [key]
   (fn [ctx event]
-    (util/assoc-chars ctx event :electoral-district)))
+    (util/assoc-chars :electoral-district ctx event key)))
 
 (def handlers
   {:start (fn [ctx event]
@@ -16,13 +16,13 @@
                       {:id (get-in event [:attrs :id])}))
    :ExternalIdentifiers
    {:ExternalIdentifier
-    {:Type {:chars (assoc-chars :external_identifier_type)}
-     :OtherType {:chars (assoc-chars :external_identifier_othertype)}
-     :Value {:chars (assoc-chars :external_identifier_value)}}}
-   :Name {:chars (assoc-chars :name)}
-   :Number {:chars (assoc-chars :number)}
-   :Type {:chars (assoc-chars :type)}
-   :OtherType {:chars (assoc-chars :other_type)}
+    {:Type        {:chars (assoc-chars :external_identifier_type)}
+     :OtherType   {:chars (assoc-chars :external_identifier_othertype)}
+     :Value       {:chars (assoc-chars :external_identifier_value)}}}
+   :Name       {:chars (assoc-chars :name)}
+   :Number     {:chars (assoc-chars :number)}
+   :Type       {:chars (assoc-chars :type)}
+   :OtherType  {:chars (assoc-chars :other_type)}
    :end (fn [ctx _]
           (-> ctx
               (update-in [:csv-data :electoral-district :data]

--- a/src/vip_feed_format_converter/xml2csv/electoral_district.clj
+++ b/src/vip_feed_format_converter/xml2csv/electoral_district.clj
@@ -1,0 +1,30 @@
+(ns vip-feed-format-converter.xml2csv.electoral-district
+  (:require [clojure.string :as str]
+            [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :external_identifier_type :external_identifier_othertype
+   :external_identifier_value :name :number :type :other_type])
+
+(defn assoc-chars [key]
+  (fn [ctx event]
+    (util/assoc-chars ctx event :electoral-district)))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :electoral-district]
+                      {:id (get-in event [:attrs :id])}))
+   :ExternalIdentifiers
+   {:ExternalIdentifier
+    {:Type {:chars (assoc-chars :external_identifier_type)}
+     :OtherType {:chars (assoc-chars :external_identifier_othertype)}
+     :Value {:chars (assoc-chars :external_identifier_value)}}}
+   :Name {:chars (assoc-chars :name)}
+   :Number {:chars (assoc-chars :number)}
+   :Type {:chars (assoc-chars :type)}
+   :OtherType {:chars (assoc-chars :other_type)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :electoral-district :data]
+                         conj (get-in ctx [:tmp :electoral-district]))
+              (update :tmp dissoc :electoral-district)))})

--- a/src/vip_feed_format_converter/xml2csv/locality.clj
+++ b/src/vip_feed_format_converter/xml2csv/locality.clj
@@ -6,24 +6,25 @@
    :external_identifier_othertype :external_identifier_value
    :name :polling_location_ids :state_id :type :other_type])
 
-(def assoc-chars (partial util/assoc-chars :locality))
+(defn assoc-chars [key]
+  (fn [ctx event]
+    (util/assoc-chars :locality ctx event key)))
 
 (def handlers
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :locality]
                       {:id (get-in event [:attrs :id])}))
-   :ElectionAdministrationId
-   {:chars #(assoc-chars %1 %2 :election_administration_id)}
+   :ElectionAdministrationId {:chars (assoc-chars :election_administration_id)}
    :ExternalIdentifiers
    {:ExternalIdentifier
-    {:Type {:chars #(assoc-chars %1 %2 :external_identifier_type)}
-     :OtherType {:chars #(assoc-chars %1 %2 :external_identifier_othertype)}
-     :Value {:chars #(assoc-chars %1 %2 :external_identifier_value)}}}
-   :Name {:chars #(assoc-chars %1 %2 :name)}
-   :PollingLocationIds {:chars #(assoc-chars %1 %2 :polling_location_ids)}
-   :StateId {:chars #(assoc-chars %1 %2 :state_id)}
-   :Type {:chars #(assoc-chars %1 %2 :type)}
-   :OtherType {:chars #(assoc-chars %1 %2 :other_type)}
+    {:Type      {:chars (assoc-chars :external_identifier_type)}
+     :OtherType {:chars (assoc-chars :external_identifier_othertype)}
+     :Value     {:chars (assoc-chars :external_identifier_value)}}}
+   :Name                     {:chars (assoc-chars :name)}
+   :PollingLocationIds       {:chars (assoc-chars :polling_location_ids)}
+   :StateId                  {:chars (assoc-chars :state_id)}
+   :Type                     {:chars (assoc-chars :type)}
+   :OtherType                {:chars (assoc-chars :other_type)}
    :end (fn [ctx _]
           (-> ctx
               (update-in [:csv-data :locality :data]

--- a/src/vip_feed_format_converter/xml2csv/locality.clj
+++ b/src/vip_feed_format_converter/xml2csv/locality.clj
@@ -15,6 +15,7 @@
             (assoc-in ctx [:tmp :locality]
                       {:id (get-in event [:attrs :id])}))
    :ElectionAdministrationId {:chars (assoc-chars :election_administration_id)}
+   ;; Note, will currently only save the LAST External Identifier in the CSV
    :ExternalIdentifiers
    {:ExternalIdentifier
     {:Type      {:chars (assoc-chars :external_identifier_type)}

--- a/src/vip_feed_format_converter/xml2csv/polling_location.clj
+++ b/src/vip_feed_format_converter/xml2csv/polling_location.clj
@@ -1,0 +1,36 @@
+(ns vip-feed-format-converter.xml2csv.polling-location
+  (:require [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :name :address_line :directions :hours :hours_open_id :is_drop_box
+   :is_early_voting :latitude :longitude :latlng_source :photo_uri])
+
+(defn assoc-chars [key]
+  (fn [ctx value]
+    (util/assoc-chars :polling-location ctx value key)))
+
+(defn assoc-intl-text [key]
+  (fn [ctx value]
+    (util/assoc-intl-text :polling-location "en" ctx value key)))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :polling-location]
+                      {:id (get-in event [:attrs :id])}))
+   :Name              {:chars (assoc-chars :name)}
+   ;; Note, for now will only take the LAST Address Line
+   :AddressLine       {:chars (assoc-chars :address_line)}
+   :Directions        {:Text {:chars (assoc-intl-text :directions)}}
+   :Hours             {:Text {:chars (assoc-intl-text :hours)}}
+   :HoursOpenId       {:chars (assoc-chars :hours_open_id)}
+   :IsDropBox         {:chars (assoc-chars :is_drop_box)}
+   :IsEarlyVoting     {:chars (assoc-chars :is_early_voting)}
+   :LatLng {:Latitude  {:chars (assoc-chars :latitude)}
+            :Longitude {:chars (assoc-chars :longitude)}
+            :Source    {:chars (assoc-chars :latlng_source)}}
+   :PhotoUri          {:chars (assoc-chars :photo_uri)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :polling-location :data]
+                         conj (get-in ctx [:tmp :polling-location]))
+              (update :tmp dissoc :polling-location)))})

--- a/src/vip_feed_format_converter/xml2csv/precinct.clj
+++ b/src/vip_feed_format_converter/xml2csv/precinct.clj
@@ -1,0 +1,39 @@
+(ns vip-feed-format-converter.xml2csv.precinct
+  (:require [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :ballot_style_id :electoral_district_ids :external_identifier_type
+   :external_identifier_othertype :external_identifier_value :is_mail_only
+   :locality_id :name :number :polling_location_ids :precinct_split_name :ward])
+
+(defn assoc-chars [key]
+  (fn [ctx value]
+    (util/assoc-chars :precinct ctx value key)))
+
+(defn assoc-intl-text [key]
+  (fn [ctx value]
+    (util/assoc-intl-text :precinct "en" ctx value key)))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :precinct]
+                      {:id (get-in event [:attrs :id])}))
+   :BallotStyleId        {:chars (assoc-chars :ballot_style_id)}
+   :ElectoralDistrictIds {:chars (assoc-chars :electoral_district_ids)}
+   :ExternalIdentifiers
+   {:ExternalIdentifier
+    {:Type        {:chars (assoc-chars :external_identifier_type)}
+     :OtherType   {:chars (assoc-chars :external_identifier_othertype)}
+     :Value       {:chars (assoc-chars :external_identifier_value)}}}
+   :IsMailOnly           {:chars (assoc-chars :is_mail_only)}
+   :LocalityId           {:chars (assoc-chars :locality_id)}
+   :Name                 {:chars (assoc-chars :name)}
+   :Number               {:chars (assoc-chars :number)}
+   :PollingLocationIds   {:chars (assoc-chars :polling_location_ids)}
+   :PrecinctSplitName    {:chars (assoc-chars :precinct_split_name)}
+   :Ward                 {:chars (assoc-chars :ward)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :precinct :data]
+                         conj (get-in ctx [:tmp :precinct]))
+              (update :tmp dissoc :precinct)))})

--- a/src/vip_feed_format_converter/xml2csv/precinct.clj
+++ b/src/vip_feed_format_converter/xml2csv/precinct.clj
@@ -20,6 +20,7 @@
                       {:id (get-in event [:attrs :id])}))
    :BallotStyleId        {:chars (assoc-chars :ballot_style_id)}
    :ElectoralDistrictIds {:chars (assoc-chars :electoral_district_ids)}
+   ;; Note, will currently only save the LAST External Identifier in the CSV
    :ExternalIdentifiers
    {:ExternalIdentifier
     {:Type        {:chars (assoc-chars :external_identifier_type)}

--- a/src/vip_feed_format_converter/xml2csv/precinct.clj
+++ b/src/vip_feed_format_converter/xml2csv/precinct.clj
@@ -10,10 +10,6 @@
   (fn [ctx value]
     (util/assoc-chars :precinct ctx value key)))
 
-(defn assoc-intl-text [key]
-  (fn [ctx value]
-    (util/assoc-intl-text :precinct "en" ctx value key)))
-
 (def handlers
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :precinct]

--- a/src/vip_feed_format_converter/xml2csv/source.clj
+++ b/src/vip_feed_format_converter/xml2csv/source.clj
@@ -1,0 +1,31 @@
+(ns vip-feed-format-converter.xml2csv.source
+  (:require [clojure.string :as str]
+            [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :date_time :description :name :organization_uri
+   :terms_of_use_uri :vip_id :version])
+
+(defn assoc-chars [key]
+  (fn [ctx event]
+    (util/assoc-chars :source ctx event key)))
+
+(def assoc-intl-text (partial util/assoc-intl-text :source "en"))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :source]
+                      {:id (get-in event [:attrs :id])}))
+   :DateTime        {:chars (assoc-chars :date_time)}
+   :Description     {:Text {:chars (fn [ctx event]
+                                     (assoc-intl-text ctx event :description))}}
+   :Name            {:chars (assoc-chars :name)}
+   :OrganizationUri {:chars (assoc-chars :organization_uri)}
+   :TouUri          {:chars (assoc-chars :terms_of_use_uri)}
+   :VipId           {:chars (assoc-chars :vip_id)}
+   :Version         {:chars (assoc-chars :version)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :source :data]
+                         conj (get-in ctx [:tmp :source]))
+              (update :tmp dissoc :source)))})

--- a/src/vip_feed_format_converter/xml2csv/source.clj
+++ b/src/vip_feed_format_converter/xml2csv/source.clj
@@ -10,15 +10,16 @@
   (fn [ctx event]
     (util/assoc-chars :source ctx event key)))
 
-(def assoc-intl-text (partial util/assoc-intl-text :source "en"))
+(defn assoc-intl-text [key]
+  (fn [ctx value]
+    (util/assoc-intl-text :source "en" ctx value key)))
 
 (def handlers
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :source]
                       {:id (get-in event [:attrs :id])}))
    :DateTime        {:chars (assoc-chars :date_time)}
-   :Description     {:Text {:chars (fn [ctx event]
-                                     (assoc-intl-text ctx event :description))}}
+   :Description     {:Text {:chars (assoc-intl-text :description)}}
    :Name            {:chars (assoc-chars :name)}
    :OrganizationUri {:chars (assoc-chars :organization_uri)}
    :TouUri          {:chars (assoc-chars :terms_of_use_uri)}

--- a/src/vip_feed_format_converter/xml2csv/state.clj
+++ b/src/vip_feed_format_converter/xml2csv/state.clj
@@ -11,8 +11,6 @@
   (fn [ctx event]
     (util/assoc-chars :state ctx event key)))
 
-(def assoc-intl-text (partial util/assoc-intl-text :state "en"))
-
 (def handlers
   {:start (fn [ctx event]
             (assoc-in ctx [:tmp :state]

--- a/src/vip_feed_format_converter/xml2csv/state.clj
+++ b/src/vip_feed_format_converter/xml2csv/state.clj
@@ -1,0 +1,32 @@
+(ns vip-feed-format-converter.xml2csv.state
+  (:require [clojure.string :as str]
+            [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :election_administration_id :external_identifier_type
+   :external_identifier_othertype :external_identifier_value
+   :name :polling_location_ids])
+
+(defn assoc-chars [key]
+  (fn [ctx event]
+    (util/assoc-chars :state ctx event key)))
+
+(def assoc-intl-text (partial util/assoc-intl-text :state "en"))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :state]
+                      {:id (get-in event [:attrs :id])}))
+   :ElectionAdministrationId {:chars (assoc-chars :election_administration_id)}
+   :ExternalIdentifiers
+   {:ExternalIdentifier
+    {:Type      {:chars (assoc-chars :external_identifier_type)}
+     :OtherType {:chars (assoc-chars :external_identifier_othertype)}
+     :Value     {:chars (assoc-chars :external_identifier_value)}}}
+   :Name                     {:chars (assoc-chars :name)}
+   :PollingLocationIds       {:chars (assoc-chars :polling_location_ids)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :state :data]
+                         conj (get-in ctx [:tmp :state]))
+              (update :tmp dissoc :state)))})

--- a/src/vip_feed_format_converter/xml2csv/state.clj
+++ b/src/vip_feed_format_converter/xml2csv/state.clj
@@ -18,6 +18,7 @@
             (assoc-in ctx [:tmp :state]
                       {:id (get-in event [:attrs :id])}))
    :ElectionAdministrationId {:chars (assoc-chars :election_administration_id)}
+   ;; Note, will currently only save the LAST External Identifier in the CSV
    :ExternalIdentifiers
    {:ExternalIdentifier
     {:Type      {:chars (assoc-chars :external_identifier_type)}

--- a/src/vip_feed_format_converter/xml2csv/street_segment.clj
+++ b/src/vip_feed_format_converter/xml2csv/street_segment.clj
@@ -1,0 +1,38 @@
+(ns vip-feed-format-converter.xml2csv.street-segment
+  (:require [clojure.string :as str]
+            [vip-feed-format-converter.util :as util]))
+
+(def headers
+  [:id :address_direction :city :includes_all_addresses :includes_all_streets
+   :odd_even_both :precinct_id :start_house_number :end_house_number :state
+   :street_direction :street_name :street_suffix :unit_number :zip])
+
+
+(defn assoc-chars [key]
+  (fn [ctx event]
+    (util/assoc-chars :street-segment ctx event key)))
+
+(def handlers
+  {:start (fn [ctx event]
+            (assoc-in ctx [:tmp :street-segment]
+                      {:id (get-in event [:attrs :id])}))
+   :AddressDirection        {:chars (assoc-chars :address_direction)}
+   :City                    {:chars (assoc-chars :city)}
+   :IncludesAllAddresses    {:chars (assoc-chars :includes_all_addresses)}
+   :IncludesAllStreets      {:chars (assoc-chars :includes_all_streets)}
+   :OddEvenBoth             {:chars (assoc-chars :odd_even_both)}
+   :PrecinctId              {:chars (assoc-chars :precinct_id)}
+   :StartHouseNumber        {:chars (assoc-chars :start_house_number)}
+   :EndHouseNumber          {:chars (assoc-chars :end_house_number)}
+   :State                   {:chars (assoc-chars :state)}
+   :StreetDirection         {:chars (assoc-chars :street_direction)}
+   :StreetName              {:chars (assoc-chars :street_name)}
+   :StreetSuffix            {:chars (assoc-chars :street_suffix)}
+   ;; Note, will currently only store the LAST Unit Number if there are multiple
+   :UnitNumber              {:chars (assoc-chars :unit_number)}
+   :Zip                     {:chars (assoc-chars :zip)}
+   :end (fn [ctx _]
+          (-> ctx
+              (update-in [:csv-data :street-segment :data]
+                         conj (get-in ctx [:tmp :street-segment]))
+              (update :tmp dissoc :street-segment)))})

--- a/src/vip_feed_format_converter/xml2csv/street_segment.clj
+++ b/src/vip_feed_format_converter/xml2csv/street_segment.clj
@@ -8,7 +8,6 @@
    :odd_even_both :precinct_id :start_house_number :end_house_number :state
    :street_direction :street_name :street_suffix :unit_number :zip])
 
-
 (defn assoc-chars [key]
   (fn [ctx event]
     (util/assoc-chars :street-segment ctx event key)))


### PR DESCRIPTION
Adds the remaining conversion types. Uses a streaming model for street-segments, as they are the biggest data set and on some large OH feeds caused the script to fail otherwise.

I've cleared that we're ok taking the last element on any of the repeatable types (AddressLine/UnitNumber/ExternalIdentifier). No one knows of any cases where they might actually be repeating for now. I've made code comments about it where those elements are.

[Pivotal Card](https://www.pivotaltracker.com/story/show/151021203)