### PR TITLE
use input-stream instead of reader

### DIFF
--- a/src/vip_feed_format_converter/core.clj
+++ b/src/vip_feed_format_converter/core.clj
@@ -17,7 +17,7 @@
   (:gen-class))
 
 (defn open-input-file [ctx]
-  (assoc ctx :input (io/reader (:in-file ctx))))
+  (assoc ctx :input (io/input-stream (:in-file ctx))))
 
 (defn close-input-file [{:keys [input] :as ctx}]
   (when input


### PR DESCRIPTION
So, apparently BOMs appear as whitespace, and if
we use a reader, it submits that whitespace first,
triggering a "Content cannot appear before prolog"
type message. If we stream, it gets subsumed properly.

For more, see https://stackoverflow.com/questions/5138696/org-xml-sax-saxparseexception-content-is-not-allowed-in-prolog?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa