### PR TITLE
I guess just return the ctx in this case?

### DIFF
--- a/src/vip_feed_format_converter/util.clj
+++ b/src/vip_feed_format_converter/util.clj
@@ -13,4 +13,5 @@
 
 (defn assoc-intl-text [top-level-key lang ctx event key]
   (if (= lang (get-in event [:prior :attrs :language]))
-    (assoc-chars top-level-key ctx event key)))
+    (assoc-chars top-level-key ctx event key)
+    ctx))


### PR DESCRIPTION
Not sure what/how the else here was getting fired, but it apparently was and was wiping out the ctx.